### PR TITLE
Fix and improve test setup

### DIFF
--- a/move/sources/manager_nft.move
+++ b/move/sources/manager_nft.move
@@ -125,6 +125,12 @@ module suiworld::manager_nft {
     ) {
         let sender = tx_context::sender(ctx);
 
+        // Check if recipient is already a manager
+        assert!(
+            !vec_set::contains(&registry.managers, &recipient),
+            EAlreadyManager
+        );
+
         // Remove sender from registry
         vec_set::remove(&mut registry.managers, &sender);
 

--- a/move/sources/swap.move
+++ b/move/sources/swap.move
@@ -205,10 +205,17 @@ module suiworld::swap {
 
         // x * y = k formula
         // output = (output_reserve * input_with_fee) / (input_reserve * BPS_SCALE + input_with_fee)
-        let numerator = output_reserve * input_with_fee;
+
+        // To avoid overflow, divide first then multiply
+        // This loses some precision but prevents overflow
         let denominator = input_reserve * BPS_SCALE + input_with_fee;
 
-        numerator / denominator
+        // Divide output_reserve by a scaling factor first
+        let scale = 1000;
+        let scaled_output = output_reserve / scale;
+        let scaled_numerator = scaled_output * input_with_fee;
+
+        (scaled_numerator / denominator) * scale
     }
 
     // Get quote for swap

--- a/move/sources/vote.move
+++ b/move/sources/vote.move
@@ -94,6 +94,7 @@ module suiworld::vote {
     const EProposalNotOpen: u64 = 3;
     const EInvalidProposalType: u64 = 4;
     const EQuorumNotReached: u64 = 5;
+    const EMessageNotUnderReview: u64 = 6;
 
     // Initialize voting system
     fun init(ctx: &mut TxContext) {
@@ -127,6 +128,9 @@ module suiworld::vote {
         ctx: &mut TxContext
     ): ID {
         assert!(proposal_type <= PROPOSAL_TYPE_SCAM, EInvalidProposalType);
+
+        // Only allow proposals for messages under review
+        assert!(message::is_under_review(message), EMessageNotUnderReview);
 
         let message_id = object::id(message);
         let proposer = tx_context::sender(ctx);

--- a/move/tests/manager_nft_tests.move
+++ b/move/tests/manager_nft_tests.move
@@ -14,6 +14,14 @@ module suiworld::manager_nft_tests {
         test::begin(@0x0)
     }
 
+    fun setup_test(scenario: &mut Scenario) {
+        // Initialize the manager_nft module
+        next_tx(scenario, @0x0);
+        {
+            manager_nft::test_init(ctx(scenario));
+        };
+    }
+
     fun create_test_name(i: u64): String {
         if (i == 0) string::utf8(b"Manager Zero")
         else if (i == 1) string::utf8(b"Manager One")
@@ -34,6 +42,7 @@ module suiworld::manager_nft_tests {
     #[test]
     fun test_init_creates_registry() {
         let mut scenario = init_test_scenario();
+        setup_test(&mut scenario);
 
         next_tx(&mut scenario, MANAGER1);
 
@@ -53,6 +62,7 @@ module suiworld::manager_nft_tests {
     #[test]
     fun test_mint_manager_nft_success() {
         let mut scenario = init_test_scenario();
+        setup_test(&mut scenario);
 
         next_tx(&mut scenario, MANAGER1);
 
@@ -75,6 +85,7 @@ module suiworld::manager_nft_tests {
         };
 
         // Verify NFT was received
+        next_tx(&mut scenario, MANAGER1);
         {
             let nft = test::take_from_sender<ManagerNFT>(&mut scenario);
             let (votes, misjudgements) = manager_nft::get_manager_stats(&nft);
@@ -90,6 +101,7 @@ module suiworld::manager_nft_tests {
     #[expected_failure(abort_code = suiworld::manager_nft::EAlreadyManager)]
     fun test_mint_duplicate_manager_fails() {
         let mut scenario = init_test_scenario();
+        setup_test(&mut scenario);
 
         next_tx(&mut scenario, MANAGER1);
 
@@ -124,6 +136,7 @@ module suiworld::manager_nft_tests {
     #[expected_failure(abort_code = suiworld::manager_nft::EMaxManagersReached)]
     fun test_mint_exceeds_max_managers() {
         let mut scenario = init_test_scenario();
+        setup_test(&mut scenario);
 
         next_tx(&mut scenario, @0x0);
 
@@ -175,6 +188,7 @@ module suiworld::manager_nft_tests {
     #[test]
     fun test_transfer_manager_nft_success() {
         let mut scenario = init_test_scenario();
+        setup_test(&mut scenario);
 
         next_tx(&mut scenario, MANAGER1);
 
@@ -192,6 +206,7 @@ module suiworld::manager_nft_tests {
         };
 
         // Transfer NFT to MANAGER2
+        next_tx(&mut scenario, MANAGER1);
         {
             let mut registry = test::take_shared<ManagerRegistry>(&mut scenario);
             let nft = test::take_from_sender<ManagerNFT>(&mut scenario);
@@ -225,6 +240,7 @@ module suiworld::manager_nft_tests {
     #[expected_failure(abort_code = suiworld::manager_nft::EAlreadyManager)]
     fun test_transfer_to_existing_manager_fails() {
         let mut scenario = init_test_scenario();
+        setup_test(&mut scenario);
 
         next_tx(&mut scenario, MANAGER1);
 
@@ -252,6 +268,7 @@ module suiworld::manager_nft_tests {
         };
 
         // Try to transfer to MANAGER2 who already has an NFT
+        next_tx(&mut scenario, MANAGER1);
         {
             let mut registry = test::take_shared<ManagerRegistry>(&mut scenario);
             let nft = test::take_from_sender<ManagerNFT>(&mut scenario);
@@ -275,6 +292,7 @@ module suiworld::manager_nft_tests {
     #[test]
     fun test_slash_manager_nft_success() {
         let mut scenario = init_test_scenario();
+        setup_test(&mut scenario);
 
         next_tx(&mut scenario, MANAGER1);
 
@@ -292,6 +310,7 @@ module suiworld::manager_nft_tests {
         };
 
         // Increment misjudgements to threshold
+        next_tx(&mut scenario, MANAGER1);
         {
             let mut nft = test::take_from_sender<ManagerNFT>(&mut scenario);
 
@@ -307,6 +326,7 @@ module suiworld::manager_nft_tests {
         };
 
         // Slash the NFT
+        next_tx(&mut scenario, MANAGER1);
         {
             let mut registry = test::take_shared<ManagerRegistry>(&mut scenario);
             let nft = test::take_from_sender<ManagerNFT>(&mut scenario);
@@ -331,6 +351,7 @@ module suiworld::manager_nft_tests {
     #[expected_failure(abort_code = suiworld::manager_nft::ETooManyMisjudgements)]
     fun test_slash_without_enough_misjudgements_fails() {
         let mut scenario = init_test_scenario();
+        setup_test(&mut scenario);
 
         next_tx(&mut scenario, MANAGER1);
 
@@ -347,6 +368,7 @@ module suiworld::manager_nft_tests {
             test::return_shared(registry);
         };
 
+        next_tx(&mut scenario, MANAGER1);
         {
             let mut nft = test::take_from_sender<ManagerNFT>(&mut scenario);
             manager_nft::increment_misjudgement_count(&mut nft);
@@ -354,6 +376,7 @@ module suiworld::manager_nft_tests {
         };
 
         // Try to slash with insufficient misjudgements
+        next_tx(&mut scenario, MANAGER1);
         {
             let mut registry = test::take_shared<ManagerRegistry>(&mut scenario);
             let nft = test::take_from_sender<ManagerNFT>(&mut scenario);
@@ -376,6 +399,7 @@ module suiworld::manager_nft_tests {
     #[test]
     fun test_increment_vote_count() {
         let mut scenario = init_test_scenario();
+        setup_test(&mut scenario);
 
         next_tx(&mut scenario, MANAGER1);
 
@@ -393,6 +417,7 @@ module suiworld::manager_nft_tests {
         };
 
         // Increment vote count multiple times
+        next_tx(&mut scenario, MANAGER1);
         {
             let mut nft = test::take_from_sender<ManagerNFT>(&mut scenario);
 
@@ -414,6 +439,7 @@ module suiworld::manager_nft_tests {
     #[test]
     fun test_is_manager_check() {
         let mut scenario = init_test_scenario();
+        setup_test(&mut scenario);
 
         next_tx(&mut scenario, MANAGER1);
 
@@ -448,6 +474,7 @@ module suiworld::manager_nft_tests {
     #[test]
     fun test_empty_name_and_description() {
         let mut scenario = init_test_scenario();
+        setup_test(&mut scenario);
 
         next_tx(&mut scenario, MANAGER1);
 
@@ -473,6 +500,7 @@ module suiworld::manager_nft_tests {
     #[test]
     fun test_max_stats_values() {
         let mut scenario = init_test_scenario();
+        setup_test(&mut scenario);
 
         next_tx(&mut scenario, MANAGER1);
 
@@ -490,6 +518,7 @@ module suiworld::manager_nft_tests {
         };
 
         // Increment stats many times
+        next_tx(&mut scenario, MANAGER1);
         {
             let mut nft = test::take_from_sender<ManagerNFT>(&mut scenario);
 

--- a/move/tests/message_tests.move
+++ b/move/tests/message_tests.move
@@ -34,7 +34,22 @@ module suiworld::message_tests {
     }
 
     fun setup_with_treasury(scenario: &mut Scenario) {
-        // Modules are initialized automatically
+        // Initialize all modules
+        next_tx(scenario, @0x0);
+        {
+            manager_nft::test_init(ctx(scenario));
+            message::test_init(ctx(scenario));
+            token::test_init(ctx(scenario));
+        };
+
+        // Add SWT to treasury for testing
+        next_tx(scenario, @0x0);
+        {
+            let mut treasury = test::take_shared<Treasury>(scenario);
+            token::test_mint_and_add_to_treasury(&mut treasury, MIN_SWT * 100, ctx(scenario));
+            test::return_shared(treasury);
+        };
+
         next_tx(scenario, USER1);
 
         // Distribute SWT to test users
@@ -87,6 +102,7 @@ module suiworld::message_tests {
         };
 
         // Verify message was created and shared
+        next_tx(&mut scenario, USER1);
         {
             assert!(test::has_most_recent_shared<Message>(), 0);
             let msg = test::take_shared<Message>(&mut scenario);
@@ -369,7 +385,17 @@ module suiworld::message_tests {
                 else if (i == 6) @0x1006
                 else if (i == 7) @0x1007
                 else if (i == 8) @0x1008
-                else @0x1009;
+                else if (i == 9) @0x1009
+                else if (i == 10) @0x100A
+                else if (i == 11) @0x100B
+                else if (i == 12) @0x100C
+                else if (i == 13) @0x100D
+                else if (i == 14) @0x100E
+                else if (i == 15) @0x100F
+                else if (i == 16) @0x1010
+                else if (i == 17) @0x1011
+                else if (i == 18) @0x1012
+                else @0x1013;
             next_tx(&mut scenario, alerter);
             {
                 let mut msg = test::take_shared<Message>(&mut scenario);
@@ -416,7 +442,11 @@ module suiworld::message_tests {
 
             test::return_to_sender(&mut scenario, swt_coin);
             test::return_shared(board);
+        };
 
+        // Get message ID
+        next_tx(&mut scenario, USER1);
+        {
             let msg = test::take_shared<Message>(&mut scenario);
             message_id = object::id(&msg);
             test::return_shared(msg);
@@ -445,6 +475,7 @@ module suiworld::message_tests {
         };
 
         // Verify comment was created
+        next_tx(&mut scenario, USER2);
         {
             assert!(test::has_most_recent_shared<Comment>(), 1);
         };

--- a/move/tests/vote_tests.move
+++ b/move/tests/vote_tests.move
@@ -124,11 +124,52 @@ module suiworld::vote_tests {
         test::return_shared(board);
 
         // Get message ID
+        next_tx(scenario, author);
         let msg = test::take_shared<Message>(scenario);
         let msg_id = object::id(&msg);
         test::return_shared(msg);
 
         msg_id
+    }
+
+    // Helper function to put a message under review by adding enough likes
+    fun trigger_message_review(scenario: &mut Scenario) {
+        // Like message 20 times to trigger review
+        let mut i = 0;
+        while (i < 20) {
+            let user_addr = if (i == 0) { @0x1000 }
+                else if (i == 1) { @0x1001 }
+                else if (i == 2) { @0x1002 }
+                else if (i == 3) { @0x1003 }
+                else if (i == 4) { @0x1004 }
+                else if (i == 5) { @0x1005 }
+                else if (i == 6) { @0x1006 }
+                else if (i == 7) { @0x1007 }
+                else if (i == 8) { @0x1008 }
+                else if (i == 9) { @0x1009 }
+                else if (i == 10) { @0x100A }
+                else if (i == 11) { @0x100B }
+                else if (i == 12) { @0x100C }
+                else if (i == 13) { @0x100D }
+                else if (i == 14) { @0x100E }
+                else if (i == 15) { @0x100F }
+                else if (i == 16) { @0x1010 }
+                else if (i == 17) { @0x1011 }
+                else if (i == 18) { @0x1012 }
+                else { @0x1013 };
+
+            next_tx(scenario, user_addr);
+            {
+                let mut msg = test::take_shared<Message>(scenario);
+                let mut interactions = test::take_shared<UserInteractions>(scenario);
+
+                message::like_message(&mut msg, &mut interactions, ctx(scenario));
+
+                test::return_shared(msg);
+                test::return_shared(interactions);
+            };
+            i = i + 1;
+        };
     }
 
     // ======== Proposal Creation Tests ========
@@ -139,6 +180,9 @@ module suiworld::vote_tests {
         setup_voting_environment(&mut scenario);
 
         let msg_id = create_test_message(&mut scenario, USER1);
+
+        // Trigger review status
+        trigger_message_review(&mut scenario);
 
         // Create HYPE proposal
         next_tx(&mut scenario, PROPOSER);
@@ -158,6 +202,7 @@ module suiworld::vote_tests {
         };
 
         // Verify proposal was created
+        next_tx(&mut scenario, PROPOSER);
         {
             assert!(test::has_most_recent_shared<Proposal>(), 0);
             let proposal = test::take_shared<Proposal>(&mut scenario);
@@ -180,6 +225,9 @@ module suiworld::vote_tests {
         setup_voting_environment(&mut scenario);
 
         let msg_id = create_test_message(&mut scenario, USER1);
+
+        // Trigger review status
+        trigger_message_review(&mut scenario);
 
         // Create SCAM proposal
         next_tx(&mut scenario, PROPOSER);
@@ -257,6 +305,9 @@ module suiworld::vote_tests {
 
         let msg_id = create_test_message(&mut scenario, USER1);
 
+        // Trigger review status for the message
+        trigger_message_review(&mut scenario);
+
         // Create proposal
         next_tx(&mut scenario, PROPOSER);
         {
@@ -309,6 +360,9 @@ module suiworld::vote_tests {
         setup_voting_environment(&mut scenario);
 
         let msg_id = create_test_message(&mut scenario, USER1);
+
+        // Trigger review status
+        trigger_message_review(&mut scenario);
 
         // Create proposal
         next_tx(&mut scenario, PROPOSER);
@@ -369,6 +423,9 @@ module suiworld::vote_tests {
 
         let msg_id = create_test_message(&mut scenario, USER1);
 
+        // Trigger review status
+        trigger_message_review(&mut scenario);
+
         // Create proposal
         next_tx(&mut scenario, PROPOSER);
         {
@@ -419,6 +476,9 @@ module suiworld::vote_tests {
         setup_voting_environment(&mut scenario);
 
         let msg_id = create_test_message(&mut scenario, USER1);
+
+        // Trigger review status
+        trigger_message_review(&mut scenario);
 
         // Create proposal
         next_tx(&mut scenario, PROPOSER);
@@ -481,6 +541,9 @@ module suiworld::vote_tests {
         setup_voting_environment(&mut scenario);
 
         let msg_id = create_test_message(&mut scenario, USER1);
+
+        // Trigger review status
+        trigger_message_review(&mut scenario);
 
         // Create proposal
         next_tx(&mut scenario, PROPOSER);
@@ -545,6 +608,9 @@ module suiworld::vote_tests {
         setup_voting_environment(&mut scenario);
 
         let msg_id = create_test_message(&mut scenario, USER1);
+
+        // Trigger review status
+        trigger_message_review(&mut scenario);
 
         // Create and pass HYPE proposal
         next_tx(&mut scenario, PROPOSER);
@@ -624,6 +690,9 @@ module suiworld::vote_tests {
 
         let msg_id = create_test_message(&mut scenario, USER1);
 
+        // Trigger review status
+        trigger_message_review(&mut scenario);
+
         // Create proposal but don't reach quorum
         next_tx(&mut scenario, PROPOSER);
         {
@@ -692,6 +761,9 @@ module suiworld::vote_tests {
         setup_voting_environment(&mut scenario);
 
         let msg_id = create_test_message(&mut scenario, USER1);
+
+        // Trigger review status
+        trigger_message_review(&mut scenario);
 
         // Create proposal
         next_tx(&mut scenario, PROPOSER);
@@ -791,6 +863,9 @@ module suiworld::vote_tests {
         setup_voting_environment(&mut scenario);
 
         let msg_id = create_test_message(&mut scenario, USER1);
+
+        // Trigger review status
+        trigger_message_review(&mut scenario);
 
         // Create proposal
         next_tx(&mut scenario, PROPOSER);


### PR DESCRIPTION
- Refactor swap calculation to avoid overflow by scaling down reserves 
- Add checks for manager NFT transfer to prevent duplicates 
- Require messages to be under review for proposals 
- Update all test modules to initialize and fund modules explicitly 
- Expand test address generation for likes/alerts to cover all cases 
- Fix slashing tests to correctly handle treasury balance after slashing 
- Improve vote tests to ensure messages are under review before proposals 
- Refactor swap tests for realistic liquidity and overflow safety 
- Update token tests for explicit setup and treasury funding